### PR TITLE
Change in imports to support openmdao version 3.43.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "matplotlib",
     "scipy>=1.13",
     "sympy",
-    "openmdao>=3.39.0",
+    "openmdao>=3.43.0",
     "mpi4py",
     "jax>=0.4.30",
     "dymos"  # Required for example in documentation and corresponding tests

--- a/uqpce/mdao/cdf/cdfresidcomp.py
+++ b/uqpce/mdao/cdf/cdfresidcomp.py
@@ -1,6 +1,6 @@
 import numpy as np
 import openmdao.api as om
-from openmdao.jax import act_tanh
+from openmdao.jax_funcs import act_tanh
 import jax.numpy as jnp
 
 

--- a/uqpce/test_suite/test_uqpce/mdao/cdf/test_cdfgroup.py
+++ b/uqpce/test_suite/test_uqpce/mdao/cdf/test_cdfgroup.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 from scipy.stats import beta, nbinom, expon
 
 from uqpce.mdao.cdf.cdfgroup import CDFGroup
-from openmdao.jax import act_tanh
+from openmdao.jax_funcs import act_tanh
 
 tanh_omega = 1e-6
 aleat_cnt = 500_000


### PR DESCRIPTION
# Summary
OpenMDAO updated a path "jax" to "jax_funcs", which resulted in import failures in UQPCE.

## Changes
* uqpce/mdao/cdf/cdfresidcomp.py
  - import changed
* uqpce/test_suite/test_uqpce/mdao/cdf/test_cdfgroup.py
  - import changed
* pyproject.toml
  - version of openmdao updated