### PR TITLE
Removed mpi4py as a requirement for UQPCE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "scipy>=1.13",
     "sympy",
     "openmdao>=3.43.0",
-    "mpi4py",
     "jax>=0.4.30",
     "dymos"  # Required for example in documentation and corresponding tests
 ]


### PR DESCRIPTION
# Changes

Package `mpi4py` was removed from the `pyproject.toml` file. Oftentimes, the problems run in UQPCE do not benefit by being run in parallel. Removing `mpi4py` as a requirement is especially useful for Windows users, where installation can be complicated.