### PR TITLE
Seed LatinHypercube resampling from the global numpy stream

### DIFF
--- a/uqpce/pce/variables/variable.py
+++ b/uqpce/pce/variables/variable.py
@@ -79,7 +79,9 @@ class Variable():
             the number of points needed to be generated
         """
         from scipy.stats.qmc import LatinHypercube
-        sampler = LatinHypercube(d=1)
+        # seed from the global numpy stream so np.random.seed() makes
+        # resampling reproducible; an unseeded engine draws OS entropy
+        sampler = LatinHypercube(d=1, seed=np.random.randint(2**31))
         samps = sampler.random(n=count)
 
         vals = self.cdf_sample(samps)


### PR DESCRIPTION
Variable.generate_samples built its LatinHypercube engine with no seed, so scipy drew fresh OS entropy on every call and the resampled variable basis (and every CI/CVaR computed from it) changed run to run even with np.random.seed() set. Seeding the engine from the global numpy stream makes the documented seed-then-initialize pattern actually reproduce, with identical distributional behavior.